### PR TITLE
Remove stray plugins directory

### DIFF
--- a/plugins/loadFormulas.client.ts
+++ b/plugins/loadFormulas.client.ts
@@ -1,5 +1,0 @@
-export default defineNuxtPlugin(() => {
-  onNuxtReady(async () => {
-    await new Promise(loadFormulas);
-  });
-});


### PR DESCRIPTION
I missed the plugins folder when wiping out the previous Nuxt implementation.